### PR TITLE
LIBILS-384. Modify DWETL to use ".env" file for configuraton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.pyc
-database_credentials.py
 data/*
 logs/*
 venv
@@ -8,3 +7,4 @@ scripts/token_dw.json
 tests/data/reference/
 **/.DS_Store
 .idea
+.env

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Download the requirements
 
 `pip install -r requirements.txt`
 
+Copy the "env_example" file to ".env" and configure:
+
+`cp env_example .env`
+
 Setup the database. See [Database Setup](docs/database_setup.md) in docs.
 
 

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -6,9 +6,18 @@ There are three ways to setup the database for use in development:
 * [Docker Postgres container](database_setup_docker_postgres.md)
 * [Local Postgres installation](database_setup_local_postgres.md)
 
+The `.env` file, in conjunction with the `config/database_credentials.py` file,
+provides the database connection information.
 
-Each method uses the `config/database_credentials.py` file for configuration. Copy the "config/database_credentials_TEMPLATE.py" file to "config/database_credentials.py", and then edit the file as appropriate for the method you are using.
+The configuration provides for an "application" database and a "test" database.
+The "application" database is used when actually running the application. The
+"test" database is used by unit/integration tests that require a database
+connection.
 
+In development, the same database can be used for both "application" and "test"
+as the tests are designed to rollback any changes on completion.
+
+In production, only the "application" database settings should be configured.
 
 ## Setting up a clean database
 

--- a/docs/database_setup_docker_postgres.md
+++ b/docs/database_setup_docker_postgres.md
@@ -65,7 +65,7 @@ where \<DATABASE_DUMP_FILENAME> is the name of the database dump. For example, i
 docker> pg_restore -d usmai_dw_etl -U postgres dump-usmai_dw_etl9.custom.Tuesday-pm
 ```
 
-8) In the "config/database_credentials.py" file the following properties can be used:
+8) In the ".env" file the following properties can be used:
 
 ```
 DB_USER = 'postgres'

--- a/docs/database_setup_local_postgres.md
+++ b/docs/database_setup_local_postgres.md
@@ -27,7 +27,7 @@ pg_restore -d usmai_dw_etl -U postgres <DATABASE_DUMP_FILENAME>
 ```
 Note: You can also create an empty database  (see Database setup)[database_setup.md]
 
-4) In the "config/database_credentials.py" file the following properties can be used:
+4) In the ".env" file the following properties can be used:
 
 ```
 DB_USER = 'postgres'

--- a/dwetl/database_credentials.py
+++ b/dwetl/database_credentials.py
@@ -1,0 +1,20 @@
+import os
+from dotenv import load_dotenv
+load_dotenv()
+
+'''
+database credentials
+'''
+
+# The username to use in connecting to the database
+DB_USER = os.getenv("DB_USER")
+# The password to use in connecting to the database
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+# The name of the database
+DB_NAME = os.getenv("DB_NAME") or 'usmai_dw_etl'
+# The hostname/IP address of the Postgres server
+DB_HOST_NAME = os.getenv("DB_HOST_NAME") or '127.0.0.1'
+# The port to use to connect to the Postgres server
+DB_PORT= os.getenv("DB_PORT") or '5432'
+
+DB_CONNECTION_STRING = f'postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST_NAME}:{DB_PORT}/{DB_NAME}'

--- a/dwetl/database_credentials.py
+++ b/dwetl/database_credentials.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -18,7 +19,13 @@ DB_HOST_NAME = os.getenv("DB_HOST_NAME")
 # The port to use to connect to the Postgres server
 DB_PORT = os.getenv("DB_PORT")
 
-DB_CONNECTION_STRING = f'postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST_NAME}:{DB_PORT}/{DB_NAME}'
+DB_CONNECTION_STRING = None
+if DB_USER and DB_PASSWORD and DB_HOST_NAME and DB_PORT and DB_NAME:
+    DB_CONNECTION_STRING = f'postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST_NAME}:{DB_PORT}/{DB_NAME}'
+
+if not DB_CONNECTION_STRING:
+    print("ERROR. Application database has not been configured. Exiting.")
+    sys.exit(1)
 
 '''
 Test Database Settings
@@ -33,7 +40,12 @@ TEST_DB_NAME = os.getenv("TEST_DB_NAME")
 TEST_DB_HOST_NAME = os.getenv("TEST_DB_HOST_NAME")
 TEST_DB_PORT = os.getenv("TEST_DB_PORT")
 
-TEST_DB_CONNECTION_STRING = f'postgresql+psycopg2://{TEST_DB_USER}:{TEST_DB_PASSWORD}@{TEST_DB_NAME}:{TEST_DB_HOST_NAME}/{TEST_DB_PORT}'
+TEST_DB_CONNECTION_STRING = None
+if TEST_DB_USER and TEST_DB_PASSWORD and TEST_DB_NAME and TEST_DB_HOST_NAME and TEST_DB_PORT:
+    TEST_DB_CONNECTION_STRING = f'postgresql+psycopg2://{TEST_DB_USER}:{TEST_DB_PASSWORD}@{TEST_DB_NAME}:{TEST_DB_HOST_NAME}/{TEST_DB_PORT}'
 
 # Boolean used by tests requiring an actual database to determine whether the test database has been configured
-TEST_DB_CONFIGURED = TEST_DB_USER and TEST_DB_PASSWORD and TEST_DB_NAME and TEST_DB_HOST_NAME and TEST_DB_PORT
+if TEST_DB_CONNECTION_STRING:
+    TEST_DB_CONFIGURED = True
+else:
+    TEST_DB_CONFIGURED = False

--- a/dwetl/database_credentials.py
+++ b/dwetl/database_credentials.py
@@ -3,18 +3,37 @@ from dotenv import load_dotenv
 load_dotenv()
 
 '''
-database credentials
-'''
+Application Database Settings
 
+Database settings for use when running the application.
+'''
 # The username to use in connecting to the database
 DB_USER = os.getenv("DB_USER")
 # The password to use in connecting to the database
 DB_PASSWORD = os.getenv("DB_PASSWORD")
 # The name of the database
-DB_NAME = os.getenv("DB_NAME") or 'usmai_dw_etl'
+DB_NAME = os.getenv("DB_NAME")
 # The hostname/IP address of the Postgres server
-DB_HOST_NAME = os.getenv("DB_HOST_NAME") or '127.0.0.1'
+DB_HOST_NAME = os.getenv("DB_HOST_NAME")
 # The port to use to connect to the Postgres server
-DB_PORT= os.getenv("DB_PORT") or '5432'
+DB_PORT = os.getenv("DB_PORT")
 
 DB_CONNECTION_STRING = f'postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST_NAME}:{DB_PORT}/{DB_NAME}'
+
+'''
+Test Database Settings
+
+Database settings for use in conjunction with the tests.
+
+Note: In production, these settings should probably not be set.
+'''
+TEST_DB_USER = os.getenv("TEST_DB_USER")
+TEST_DB_PASSWORD = os.getenv("TEST_DB_PASSWORD")
+TEST_DB_NAME = os.getenv("TEST_DB_NAME")
+TEST_DB_HOST_NAME = os.getenv("TEST_DB_HOST_NAME")
+TEST_DB_PORT = os.getenv("TEST_DB_PORT")
+
+TEST_DB_CONNECTION_STRING = f'postgresql+psycopg2://{TEST_DB_USER}:{TEST_DB_PASSWORD}@{TEST_DB_NAME}:{TEST_DB_HOST_NAME}/{TEST_DB_PORT}'
+
+# Boolean used by tests requiring an actual database to determine whether the test database has been configured
+TEST_DB_CONFIGURED = TEST_DB_USER and TEST_DB_PASSWORD and TEST_DB_NAME and TEST_DB_HOST_NAME and TEST_DB_PORT

--- a/env_example
+++ b/env_example
@@ -1,16 +1,18 @@
+# Example .env file
+# Make a copy of this file named ".env" and fill out the properties
+# Note: The .env file should _not_ be checked in to Git!
+
+
 '''
 database credentials
 '''
-
 # The username to use in connecting to the database
-DB_USER =
+DB_USER=
 # The password to use in connecting to the database
-DB_PASSWORD =
+DB_PASSWORD=
 # The name of the database
-DB_NAME = 'usmai_dw_etl'
+DB_NAME=usmai_dw_etl
 # The hostname/IP address of the Postgres server
-DB_HOST_NAME= '127.0.0.1'
+DB_HOST_NAME=127.0.0.1
 # The port to use to connect to the Postgres server
-DB_PORT= '5432'
-
-DB_CONNECTION_STRING = f'postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST_NAME}:{DB_PORT}/{DB_NAME}'
+DB_PORT=5432

--- a/env_example
+++ b/env_example
@@ -4,7 +4,7 @@
 
 
 '''
-database credentials
+Database settings
 '''
 # The username to use in connecting to the database
 DB_USER=
@@ -16,3 +16,22 @@ DB_NAME=usmai_dw_etl
 DB_HOST_NAME=127.0.0.1
 # The port to use to connect to the Postgres server
 DB_PORT=5432
+
+'''
+Test database settings
+
+These settings are used for configuring the database used
+by the tests. They should NOT be set in a production
+environment.
+'''
+# The username to use in connecting to the database
+TEST_DB_USER=
+# The password to use in connecting to the database
+TEST_DB_PASSWORD=
+# The name of the database
+TEST_DB_NAME=
+# The hostname/IP address of the Postgres server
+TEST_DB_HOST_NAME=
+# The port to use to connect to the Postgres server
+TEST_DB_PORT=
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 colorama==0.4.1
 sql==0.4.0
 SQLAlchemy==1.3.3
+psycopg2==2.8.3
 httplib2==0.12.0
 google_api_python_client==1.7.9
 python-dotenv==0.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sql==0.4.0
 SQLAlchemy==1.3.3
 httplib2==0.12.0
 google_api_python_client==1.7.9
+python-dotenv==0.10.3


### PR DESCRIPTION
Modified the application to use the "python-dotenv" package, which allows server-specific configuration information to be placed in a ".env" file in the root directory.

Added a "dwetl/database_credentials.py" file which uses the settings in the ".env" file for the database configuration. Modified ".gitignore" so "database_credentials.py" file would be included in the repository.

Deleted the "dwetl/database_credentials_TEMPLATE.py" file as it was no longer needed.

Added an "env_example" file to serve as a template for the ".env" file. Modified .gitignore so that
the ".env" file would ignored.

Updated the documentation.

https://issues.umd.edu/browse/LIBILS-384

