### PR TITLE
LIBILS-390. Simplify database session setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Copy the "env_example" file to ".env" and configure:
 
 Setup the database. See [Database Setup](docs/database_setup.md) in docs.
 
+See [Database Usage](docs/database_usage.md) for information about
+programmatically accessing to the database.
+
 
 
 ## Running the application

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -1,5 +1,11 @@
 # Database Setup
 
+## Introduction
+
+This document describes how to setup and configure the a database for
+use by the application. For information about programmatically accessing
+the database, see [Database Usage](database_usage.md).
+ 
 There are three ways to setup the database for use in development:
 
 * Use the pgcommondev server

--- a/docs/database_usage.md
+++ b/docs/database_usage.md
@@ -1,0 +1,45 @@
+# Database Usage
+
+## Introduction
+
+This document provides information about programmatically accessing the
+database.
+
+For information about setting up the database, see
+[Database Setup](database_setup.md)
+
+## Context Managers
+
+As recommended in the [SQL Alchemy documentation](https://docs.sqlalchemy.org/en/13/orm/session_basics.html)
+(see the "When do I construct a Session, when do I commit it, and when do I close
+it?" section) database access is performed within a Python "context manager".
+
+There are two context manager functions in the "dwetl/__init.py___" file for
+accessing the database:
+
+* dwetl.database_session
+* dwetl.test_database_session
+
+The "dwetl.database_session" is used by the application when the changes should
+actually be stored in the database. All changes made within the session are
+committed, unless an exception is raised, in which case all the changes are
+rolled back.
+
+The "dwetl.test_database_session" is used by unit/integration tests. Any changes
+made within the session are automatically rolled back when the session exits.
+
+Both the "dwetl .database_session" and "dwetl.test_database_session" are used
+in the same way:
+
+```
+import dweetl
+
+...
+
+with dwetl.database_session() as session:
+  # Do database access
+```
+
+When writing a record to the database, an explicit "session.commit()" should
+_not_ be used.
+

--- a/dwetl/__init__.py
+++ b/dwetl/__init__.py
@@ -1,1 +1,104 @@
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy import create_engine
+import dwetl.database_credentials as database_credentials
+from contextlib import contextmanager
+
 version = "1.0.0"
+
+Base = None
+
+@contextmanager
+def database_session():
+    """
+    Returns a database session for application use.
+
+    All changes made in the session will be committed, unless an exception is
+    raised. If an exception is raised, all uncommitted changes will be rolled
+    back.
+
+    The database session will automatically commit the changes when the
+    session exits, so no explicit commit is needed by the code.
+
+    Sample Usage:
+
+      with dwetl.database_session() as session:
+         <Access datatabase>
+
+    :return: a database session for application use.
+    """
+    global Base
+    # See https://docs.sqlalchemy.org/en/13/orm/session_transaction.html
+    db_settings = database_credentials.db_settings()
+    engine = create_engine(db_settings['DB_CONNECTION_STRING'])
+
+    # Populate Base class, if needed.
+    if Base is None:
+        Base = automap_base()
+        Base.prepare(engine, reflect=True)
+
+    # connect to the database
+    connection = engine.connect()
+
+    # bind an individual Session to the connection
+    s = sessionmaker()
+    session = s(bind=connection)
+
+    try:
+        yield session
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+@contextmanager
+def test_database_session():
+    """
+    Returns a database session for use with testing.
+
+    All changes made in the session will be rolled back when the session
+    exits.
+
+    Sample Usage:
+
+      with dwetl.test_database_session() as session:
+         <Access datatabase>
+
+    :return: a database session for use with testing that always rolls back,
+             removing the changes made in the session.
+    """
+    global Base
+    # See https://docs.sqlalchemy.org/en/13/orm/session_transaction.html
+    test_db_settings = database_credentials.test_db_settings()
+    engine = create_engine(test_db_settings['TEST_DB_CONNECTION_STRING'])
+
+    # Populate Base class, if needed.
+    if Base is None:
+        Base = automap_base()
+        Base.prepare(engine, reflect=True)
+
+    # connect to the database
+    connection = engine.connect()
+
+    # begin a non-ORM transaction
+    # Using a transactiom, so that we can rollback, even if there
+    # are session.commit() calls
+    trans = connection.begin()
+
+    # bind an individual Session to the connection
+    s = sessionmaker()
+    session = s(bind=connection)
+
+    try:
+        # begin a non-ORM transaction
+        yield session
+        # Never commit as we are just testing
+    except:
+        session.rollback()
+        raise
+    finally:
+        # Always rollback
+        session.rollback()
+        trans.rollback()

--- a/dwetl/job_info.py
+++ b/dwetl/job_info.py
@@ -48,5 +48,4 @@ class JobInfoFactory():
 
         record = cls.table_base_class(**row)
         cls.session.add(record)
-        cls.session.commit()
         return JobInfo(cls.prcsng_cycle_id, cls.user_id, cls.job_version_no, cls.job_exectn_id)

--- a/dwetl/writer/sql_alchemy_writer.py
+++ b/dwetl/writer/sql_alchemy_writer.py
@@ -20,6 +20,5 @@ class SqlAlchemyWriter(Writer):
             # insert the row into SQLAlchemy table base class
             record = self.table_base_class(**row_dict)
             self.session.add(record)
-            self.session.commit()
         except exc.SQLAlchemyError as e:
             self.session.rollback()

--- a/tests/reader/test_sql_alchemy_reader.py
+++ b/tests/reader/test_sql_alchemy_reader.py
@@ -1,36 +1,19 @@
 import unittest
 from dwetl.reader.sql_alchemy_reader import SqlAlchemyReader
 import dwetl.database_credentials as database_credentials
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.automap import automap_base
-from sqlalchemy import create_engine
 import datetime
+import dwetl
 
 
 class TestSqlAlchemyReader(unittest.TestCase):
     @unittest.skipUnless(database_credentials.test_db_configured(), "Test database is not configured.")
     def setUp(self):
-        # See https://docs.sqlalchemy.org/en/13/orm/session_transaction.html
-        test_db_settings = database_credentials.test_db_settings()
-        self.engine = create_engine(test_db_settings['TEST_DB_CONNECTION_STRING'])
-        # connect to the database
-        self.connection = self.engine.connect()
-
-        # begin a non-ORM transaction
-        self.trans = self.connection.begin()
-
-        # bind an individual Session to the connection
-        s = sessionmaker()
-        self.session = s(bind=self.connection)
-
-        self.Base = automap_base()
-        self.Base.prepare(self.engine, reflect=True)
+        pass
 
     def setup_rows(self, session, base_table_class, rows):
         for row_dict in rows:
-            record = self.table_base_class(**row_dict)
-            self.session.add(record)
-            self.session.commit()
+            record = base_table_class(**row_dict)
+            session.add(record)
 
     def append_job_info(self, row_dict, processing_cycle_field_name, processing_cycle_id):
         job_info = {
@@ -45,71 +28,63 @@ class TestSqlAlchemyReader(unittest.TestCase):
         row_dict.update(job_info)
 
     def test_read_empty_table(self):
-        self.table_base_class = self.Base.classes.dw_stg_1_mai01_z00
-        reader = SqlAlchemyReader(self.session, self.table_base_class, 'em_create_dw_prcsng_cycle_id', 9999)
+        with dwetl.test_database_session() as session:
+            table_base_class = dwetl.Base.classes.dw_stg_1_mai01_z00
+            reader = SqlAlchemyReader(session, table_base_class, 'em_create_dw_prcsng_cycle_id', 9999)
 
-        results = []
-        for row in reader:
-            results.append(row)
+            results = []
+            for row in reader:
+                results.append(row)
 
-        self.assertEqual(0, len(results))
+            self.assertEqual(0, len(results))
 
     def test_read_rows_from_table(self):
-        # Add some sample rows to the "dw_stg_1_mai01_z00" table
-        self.table_base_class = self.Base.classes.dw_stg_1_mai01_z00
+        with dwetl.test_database_session() as session:
+            # Add some sample rows to the "dw_stg_1_mai01_z00" table
+            table_base_class = dwetl.Base.classes.dw_stg_1_mai01_z00
 
-        rows = [
-            {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000205993',
-             'z00_doc_number': '000205993', 'z00_no_lines': '0043', 'z00_data_len': '001583'},
-            {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000245526'}
-        ]
+            rows = [
+                {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000205993',
+                 'z00_doc_number': '000205993', 'z00_no_lines': '0043', 'z00_data_len': '001583'},
+                {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000245526'}
+            ]
 
-        for row in rows:
-            self.append_job_info(row, 'em_create_dw_prcsng_cycle_id', 9999)
+            for row in rows:
+                self.append_job_info(row, 'em_create_dw_prcsng_cycle_id', 9999)
 
-        self.setup_rows(self.session, self.table_base_class, rows)
+            self.setup_rows(session, table_base_class, rows)
 
-        reader = SqlAlchemyReader(self.session, self.table_base_class, 'em_create_dw_prcsng_cycle_id', 9999)
-        results = []
-        for row in reader:
-            results.append(row)
+            reader = SqlAlchemyReader(session, table_base_class, 'em_create_dw_prcsng_cycle_id', 9999)
+            results = []
+            for row in reader:
+                results.append(row)
 
-        self.assertEqual(2, len(results))
-        self.assertEqual('000205993', results[0]['rec_trigger_key'])
-        self.assertEqual('000245526', results[1]['rec_trigger_key'])
+            self.assertEqual(2, len(results))
+            self.assertEqual('000205993', results[0]['rec_trigger_key'])
+            self.assertEqual('000245526', results[1]['rec_trigger_key'])
 
     def test_read_rows_from_table_with_multiple_processing_ids(self):
-        # Add some sample rows to the "dw_stg_1_mai01_z00" table
-        self.table_base_class = self.Base.classes.dw_stg_1_mai01_z00
+        with dwetl.test_database_session() as session:
+            # Add some sample rows to the "dw_stg_1_mai01_z00" table
+            table_base_class = dwetl.Base.classes.dw_stg_1_mai01_z00
 
-        rows = [
-            {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000205993',
-             'z00_doc_number': '000205993', 'z00_no_lines': '0043', 'z00_data_len': '001583'},
-            {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000245526'}
-        ]
+            rows = [
+                {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000205993',
+                 'z00_doc_number': '000205993', 'z00_no_lines': '0043', 'z00_data_len': '001583'},
+                {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000245526'}
+            ]
 
-        # Use different em_create_dw_prcsng_cycle_ids for each row
-        self.append_job_info(rows[0], 'em_create_dw_prcsng_cycle_id', 1234)
-        self.append_job_info(rows[1], 'em_create_dw_prcsng_cycle_id', 9876)
+            # Use different em_create_dw_prcsng_cycle_ids for each row
+            self.append_job_info(rows[0], 'em_create_dw_prcsng_cycle_id', 1234)
+            self.append_job_info(rows[1], 'em_create_dw_prcsng_cycle_id', 9876)
 
-        self.setup_rows(self.session, self.table_base_class, rows)
+            self.setup_rows(session, table_base_class, rows)
 
-        reader = SqlAlchemyReader(self.session, self.table_base_class, 'em_create_dw_prcsng_cycle_id', 9876)
-        results = []
-        for row in reader:
-            results.append(row)
+            reader = SqlAlchemyReader(session, table_base_class, 'em_create_dw_prcsng_cycle_id', 9876)
+            results = []
+            for row in reader:
+                results.append(row)
 
-        # Only the row matching the em_create_dw_prcsng_cycle_id should be returned
-        self.assertEqual(1, len(results))
-        self.assertEqual('000245526', results[0]['rec_trigger_key'])
-
-    def tearDown(self):
-        self.session.close()
-
-        # rollback - everything that happened with the
-        # Session above (including calls to commit())
-        # is rolled back.
-        self.trans.rollback()
-
-        # return connection to the Engine
-        self.connection.close()
+            # Only the row matching the em_create_dw_prcsng_cycle_id should be returned
+            self.assertEqual(1, len(results))
+            self.assertEqual('000245526', results[0]['rec_trigger_key'])

--- a/tests/test_job_info.py
+++ b/tests/test_job_info.py
@@ -1,35 +1,12 @@
 import unittest
-import pdb
 import datetime
 import getpass
 import dwetl.database_credentials as database_credentials
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.automap import automap_base
-from sqlalchemy import create_engine
-from sqlalchemy import func
 from dwetl.job_info import JobInfo, JobInfoFactory
 import dwetl
 
+
 class TestJobInfo(unittest.TestCase):
-
-    @unittest.skipUnless(database_credentials.test_db_configured(), "Test database is not configured.")
-    def setUp(self):
-        # See https://docs.sqlalchemy.org/en/13/orm/session_transaction.html
-        test_db_settings = database_credentials.test_db_settings()
-        self.engine = create_engine(test_db_settings['TEST_DB_CONNECTION_STRING'])
-        # connect to the database
-        self.connection = self.engine.connect()
-
-        # begin a non-ORM transaction
-        self.trans = self.connection.begin()
-
-        # bind an individual Session to the connection
-        s = sessionmaker()
-        self.session = s(bind=self.connection)
-
-        self.Base = automap_base()
-        self.Base.prepare(self.engine, reflect=True)
-
     def test_create_job_info(self):
         job_info = JobInfo(4, 'thschone', '1.0.0', 1)
 
@@ -38,22 +15,24 @@ class TestJobInfo(unittest.TestCase):
         self.assertEqual('1.0.0', job_info.job_version_no)
         self.assertEqual(1, job_info.job_exectn_id)
 
+    @unittest.skipUnless(database_credentials.test_db_configured(), "Test database is not configured.")
     def test_job_info_factory_create_from_db(self):
         # expected user
         expected_user = getpass.getuser()
 
-        table_base_class = self.Base.classes.dw_prcsng_cycle
-        job_info = JobInfoFactory.create_job_info_from_db(self.session, table_base_class)
-        self.assertEqual(1, job_info.prcsng_cycle_id)
-        self.assertEqual(1, job_info.job_exectn_id)
-        self.assertEqual(dwetl.version, job_info.job_version_no)
-        self.assertEqual(expected_user, job_info.user_id)
-        
-        added_record = self.session.query(table_base_class).filter(table_base_class.dw_prcsng_cycle_id == 1).one().__dict__
-        self.assertEqual(1, added_record['dw_prcsng_cycle_id'])
-        self.assertEqual(expected_user, added_record['em_create_user_id'])
+        with dwetl.test_database_session() as session:
+            table_base_class = dwetl.Base.classes.dw_prcsng_cycle
+            job_info = JobInfoFactory.create_job_info_from_db(session, table_base_class)
+            self.assertEqual(1, job_info.prcsng_cycle_id)
+            self.assertEqual(1, job_info.job_exectn_id)
+            self.assertEqual(dwetl.version, job_info.job_version_no)
+            self.assertEqual(expected_user, job_info.user_id)
 
+            added_record = session.query(table_base_class).filter(table_base_class.dw_prcsng_cycle_id == 1).one().__dict__
+            self.assertEqual(1, added_record['dw_prcsng_cycle_id'])
+            self.assertEqual(expected_user, added_record['em_create_user_id'])
 
+    @unittest.skipUnless(database_credentials.test_db_configured(), "Test database is not configured.")
     def test_job_info_factory_create_from_db_existing(self):
         '''test when there are existing entries in the dw_prcsng_cycle table'''
         #add existing entry
@@ -66,28 +45,17 @@ class TestJobInfo(unittest.TestCase):
             'em_create_tmstmp': datetime.datetime.now(),
             'em_create_user_id': 'thschone'
         }
-        table_base_class = self.Base.classes.dw_prcsng_cycle
-        record = table_base_class(**row)
-        self.session.add(record)
-        self.session.commit()
 
-        job_info = JobInfoFactory.create_job_info_from_db(self.session, table_base_class)
-        self.assertEqual(4, job_info.prcsng_cycle_id)
+        with dwetl.test_database_session() as session:
+            table_base_class = dwetl.Base.classes.dw_prcsng_cycle
+            record = table_base_class(**row)
+            session.add(record)
+            session.commit()
 
-        expected_version = dwetl.version
-        self.assertEqual(expected_version, job_info.job_version_no)
+            job_info = JobInfoFactory.create_job_info_from_db(session, table_base_class)
+            self.assertEqual(4, job_info.prcsng_cycle_id)
 
-        self.assertEqual(1, job_info.job_exectn_id)
+            expected_version = dwetl.version
+            self.assertEqual(expected_version, job_info.job_version_no)
 
-
-
-    def tearDown(self):
-        self.session.close()
-
-        # rollback - everything that happened with the
-        # Session above (including calls to commit())
-        # is rolled back.
-        self.trans.rollback()
-
-        # return connection to the Engine
-        self.connection.close()
+            self.assertEqual(1, job_info.job_exectn_id)

--- a/tests/writer/test_sql_alchemy_writer.py
+++ b/tests/writer/test_sql_alchemy_writer.py
@@ -1,65 +1,38 @@
 import unittest
 from dwetl.writer.sql_alchemy_writer import SqlAlchemyWriter
 import dwetl.database_credentials as database_credentials
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.automap import automap_base
-from sqlalchemy import create_engine
 import datetime
-
+import dwetl
 
 class TestSqlAlchemyWriter(unittest.TestCase):
     @unittest.skipUnless(database_credentials.test_db_configured(), "Test database is not configured.")
     def setUp(self):
-        # See https://docs.sqlalchemy.org/en/13/orm/session_transaction.html
-        test_db_settings = database_credentials.test_db_settings()
-        self.engine = create_engine(test_db_settings['TEST_DB_CONNECTION_STRING'])
-        # connect to the database
-        self.connection = self.engine.connect()
-
-        # begin a non-ORM transaction
-        self.trans = self.connection.begin()
-
-        # bind an individual Session to the connection
-        s = sessionmaker()
-        self.session = s(bind=self.connection)
-
-        self.Base = automap_base()
-        self.Base.prepare(self.engine, reflect=True)
+        pass
 
     def test_add_row_to_table(self):
-        table_base_class = self.Base.classes.dw_stg_1_mai01_z00
+        with dwetl.test_database_session() as session:
+            table_base_class = dwetl.Base.classes.dw_stg_1_mai01_z00
 
-        row_dict = {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000007520',
-                    'z00_doc_number': '000007520', 'z00_no_lines': '0041', 'z00_data_len': '001504'}
+            row_dict = {'rec_type_cd': 'D', 'db_operation_cd': 'U', 'rec_trigger_key': '000007520',
+                        'z00_doc_number': '000007520', 'z00_no_lines': '0041', 'z00_data_len': '001504'}
 
-        job_info = {
-            'em_create_dw_prcsng_cycle_id': 9999,
-            'em_create_dw_job_exectn_id': 9999,
-            'em_create_dw_job_name': 'TEST',
-            'em_create_dw_job_version_no': '0.0',
-            'em_create_user_id': 'test_user',
-            'em_create_tmstmp': datetime.datetime.now()
-        }
+            job_info = {
+                'em_create_dw_prcsng_cycle_id': 9999,
+                'em_create_dw_job_exectn_id': 9999,
+                'em_create_dw_job_name': 'TEST',
+                'em_create_dw_job_version_no': '0.0',
+                'em_create_user_id': 'test_user',
+                'em_create_tmstmp': datetime.datetime.now()
+            }
 
-        row_dict.update(job_info)
+            row_dict.update(job_info)
 
-        writer = SqlAlchemyWriter(self.session, table_base_class)
-        writer.write_row(row_dict)
+            writer = SqlAlchemyWriter(session, table_base_class)
+            writer.write_row(row_dict)
 
-        # Verify that the row was added
-        result = self.session.query(table_base_class).filter(table_base_class.em_create_dw_prcsng_cycle_id == '9999').one()
+            # Verify that the row was added
+            result = session.query(table_base_class).filter(table_base_class.em_create_dw_prcsng_cycle_id == '9999').one()
 
-        result_dict = result.__dict__
-        self.assertEqual('000007520', result_dict['rec_trigger_key'])
-        self.assertEqual('001504', result_dict['z00_data_len'])
-
-    def tearDown(self):
-        self.session.close()
-
-        # rollback - everything that happened with the
-        # Session above (including calls to commit())
-        # is rolled back.
-        self.trans.rollback()
-
-        # return connection to the Engine
-        self.connection.close()
+            result_dict = result.__dict__
+            self.assertEqual('000007520', result_dict['rec_trigger_key'])
+            self.assertEqual('001504', result_dict['z00_data_len'])


### PR DESCRIPTION
Simplified database session setup by creating two "context manager" functions in
dwetl/__init__.py:

* database_session
* test_database_session

These context manager are used via the Python "with" idiom to ensure that the session is
properly setup and destroyed. The "database_session" context manager will commit the
changes in the session to the database (unless an exception is raised). The "test_database_session" context manager will always roll back the changes made in the session (and so it useful when writing unit/integration tests).

https://issues.umd.edu/browse/LIBILS-390