### PR TITLE
LIBILS-391. Add "invoke" task runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ Copy the "env_example" file to ".env" and configure:
 
 Setup the database. See [Database Setup](docs/database_setup.md) in docs.
 
+## "invoke" Task Runner
 
+A number of administrative tasks are available using the "invoke" task runner.
+
+To see the list of available tasks, run:
+
+```
+> invoke --list
+```
+
+See [Tasks](docs/tasks.md) for more information about the available tasks.
 
 ## Running the application
 

--- a/ddl/drop_db.sql
+++ b/ddl/drop_db.sql
@@ -1,0 +1,18 @@
+-- This SQL script terminates all active connections to the "usmai_dw_etl" database,
+-- then drops the database.
+--
+-- WARNING: Using the SQL script will DESTROY all the data in the  "usmai_dw_etl" database.
+
+-- Terminate active connections
+-- See: https://dba.stackexchange.com/questions/11893/force-drop-db-while-others-may-be-connected
+
+-- Make sure no one can connect to this database by updating the system catalog
+UPDATE pg_database SET datallowconn = 'false' WHERE datname = 'usmai_dw_etl';
+
+-- Force disconnection of all clients connected to this database, using pg_terminate_backend
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE datname = 'usmai_dw_etl';
+
+-- DROP the usmai_dw_etl database
+DROP DATABASE 'usmai_dw_etl'

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -21,20 +21,28 @@ In production, only the "application" database settings should be configured.
 
 ## Setting up a clean database
 
-The DDL for the entire database is located in the ddl directory and named usmai_dw_etl.sql.
+The DDL for the entire database is located in the "ddl" directory and named
+"usmai_dw_etl.sql".
 
-This command generated the DDL for usma_dw_etl.sql. This file should be updated if there is a change to the database schema.
+The DDL in the "usmai_dw_etl.sql" file was generated using the following
+command:
+
 ```
 > pg_dump -U postgres -h localhost -p 5432 usmai_dw_etl -Fp --create --clean --schema-only -f Development/usmai_dw_etl.sql
 ```
 
-To recreate the database from usmai_dw_etl.sql run the following command from the ddl directory:
-NOTE: This will destroy existing db and create a new empty usmai_dw_etl database.
+The "usmai_dw_etl.sql" file should be updated whenever there is a change to the
+database schema.
+
+To recreate the database from the "usmai_dw_etl.sql",  run the following
+command:
+
+**Note:** This command will DESTROY the existing db and create a new empty
+"usmai_dw_etl" database.
 
 ```
-psql -U <DB_USERNAME> -d postgres -f usmai_dw_etl.sql --host=127.0.0.1
+> invoke database-reset
 ```
-Where `<DB_USERNAME>` is the username for your database. 
 
 ### Database Migrations
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,56 @@
+# Tasks
+
+## Introduction
+
+This document describes the tasks available via the "invoke" task runner.
+
+## The "invoke" task runner
+
+See [http://docs.pyinvoke.org/en/1.3/](http://docs.pyinvoke.org/en/1.3/) for
+documentation on the "invoke" package.
+
+To see the list of available tasks, run:
+
+```
+> invoke --list
+```
+
+To run a particular task, use:
+
+```
+> invoke <TASK_NAME>
+```
+
+where \<TASK_NAME> is the name of the task.
+
+
+## Tasks
+
+### database-reset
+
+Drops the application database, and restores an empty database using the
+"ddl/usmai_dw_etl.sql" file.
+
+**Warning:** This task will DESTROY the existing database.
+
+This task also terminates all active sessions to the database (this is
+needed to actually drop the database).
+
+### sheets-to-json
+
+Generates the JSON files in the "table_config/" subdirectory from the Google
+Sheets document.
+
+This task will prompt for OAuth authorization, if needed.
+
+### test-database-teset
+
+Drops the test database, and restores an empty database using the
+"ddl/usmai_dw_etl.sql" file.
+
+**Note:** If, as is commonly the case in local development, the "application"
+and "test" database are the same database, this command would also drop and
+restore the application database.
+
+This task also terminates all active sessions to the database (this is
+needed to actually drop the database).

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,11 @@ httplib2==0.12.0
 google_api_python_client==1.7.9
 python-dotenv==0.10.3
 pytest==4.0.1
+
+# Needed for "scripts/sheetstojson.py"
+oauth2client==4.1.3
+
+# Task runner
+invoke==1.3.0
+
+

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,75 @@
+from invoke import task, exceptions
+import dwetl.database_credentials
+
+@task
+def sheets_to_json(c):
+    """
+    Generates the JSON files in the table_config/ subdirectory from Google Sheets.
+    """
+    c.run('cd scripts; python sheetstojson.py', pty=True)
+
+@task
+def database_reset(c):
+    """
+    Resets the application database. WARNING: This will DESTORY any existing data in the database.
+    """
+    db_settings = dwetl.database_credentials.db_settings()
+    db_user = db_settings['DB_USER']
+    db_host = db_settings['DB_HOST_NAME']
+    db_port = db_settings['DB_PORT']
+    db_password = db_settings['DB_PASSWORD']
+    reset_database(c, db_host, db_port, db_user, db_password)
+
+@task
+def test_database_reset(c):
+    """
+    Resets the test database.
+
+    WARNING: This task will DESTROY any existing data in the test
+    database.
+    """
+    test_db_settings = dwetl.database_credentials.test_db_settings()
+    test_db_user = test_db_settings['TEST_DB_USER']
+    test_db_host = test_db_settings['TEST_DB_HOST_NAME']
+    test_db_port = test_db_settings['TEST_DB_PORT']
+    test_db_password = test_db_settings['TEST_DB_PASSWORD']
+    reset_database(c, test_db_host, test_db_port, test_db_user, test_db_password)
+
+
+# Task helper function
+def reset_database(context, db_host, db_port, db_user, db_password):
+    pg_password=f'PGPASSWORD={db_password} '
+    psql_cmd = f'psql -U {db_user} -d postgres --host={db_host} --port={db_port}'
+
+    ask_for_confirmation = True
+    if (db_host == 'localhost' or db_host == '127.0.0.1') and db_port == '5432':
+        # Assume localhost:5432 and 127.0.0.1:5432 are local Postgres
+        ask_for_confirmation = False
+
+    if ask_for_confirmation:
+        confirm = input(f"Are you sure you want to reset {db_host}:{db_port}? ")
+        confirm = confirm.lower()
+        if not((confirm == 'y') or (confirm == 'yes')):
+            print("Database has not been reset.")
+            exit()
+
+    print(f'Resetting database at {db_host}:{db_port}')
+    print('-----------')
+    print('Terminating sessions and dropping database')
+    terminate_sessions = psql_cmd + ' -f ddl/drop_db.sql'
+    print('\t' + terminate_sessions)
+
+    if context.run(pg_password + terminate_sessions):
+        print('-----------')
+        print('Sessions terminated')
+    else:
+        raise Exception()
+        print('An error has occurred')
+
+    print('Creating database from DDL')
+    load_ddl = psql_cmd + ' -f ddl/usmai_dw_etl.sql'
+    print(load_ddl)
+    if context.run(pg_password + load_ddl):
+        print('-----------')
+        print('Database reset')
+


### PR DESCRIPTION
Added "invoke" package to "requirements.txt".

Added the following tasks in "tasks.py":

* database-reset - Drops and rebuilds the application database
* sheets-to-json - Generates the JSON files in the table_config/ subdirectory from Google Sheets, using the "scripts/sheetstojson.py" script
* test-database-reset - Drops and rebuilds the application database

Updated the documentation.

https://issues.umd.edu/browse/LIBILS-391